### PR TITLE
Replace second by cl-second

### DIFF
--- a/git-msg-prefix.el
+++ b/git-msg-prefix.el
@@ -134,7 +134,7 @@ Relevant meaning the result of `git-msg-prefix-regex'
 substitution."
   (interactive)
   (insert
-   (second
+   (cl-second
     (s-match git-msg-prefix-regex
              (git-msg-prefix-input-fun)))))
 


### PR DESCRIPTION
cl is deprecated and replaced by cl-lib. This fix updates `second` and solves a problem found when used in combination with magit commit, namely, it fixes:
`hint: Waiting for your editor to close the file... Waiting for Emacs...
*ERROR*: Symbol’s function definition is void: second `